### PR TITLE
add function formatDataValue in options

### DIFF
--- a/Gauge.js
+++ b/Gauge.js
@@ -8,7 +8,14 @@
 		this.chart = chart;
 		this.ctx = chart.ctx;
 		this.limits = config.data.datasets[0].gaugeLimits;
-		this.data = config.data.datasets[0].gaugeData;
+        this.data = config.data.datasets[0].gaugeData;
+        if (config.options.formatDataValue) {
+			this.formatDataValue = config.options.formatDataValue;
+		} else {
+			this.formatDataValue = function(value) {
+				return value;
+			}
+		}
 		var options = chart.options;
 		this.fontSize = options.defaultFontSize;
 		this.fontStyle = options.defaultFontFamily;
@@ -112,7 +119,7 @@
 		}
 	};
 	GaugeChartHelper.prototype.renderValueLabel = function() {
-		var label = this.data.value.toString();
+		var label = this.formatDataValue(this.data.value).toString();
 		var ctx = this.ctx;
 		ctx.font = "30px " + this.fontStyle;
 		var stringWidth = ctx.measureText(label).width;


### PR DESCRIPTION
with this atributte u can modify the text display in the center of gauge. like this example:
```
var ctx = document.getElementById("chartjs-gauge").getContext("2d");
            new Chart(ctx, {
                type: "tsgauge",
                data: {
                    datasets: [{
                        backgroundColor: ["#0fdc63", "#fd9704", "#ff7143"],
                        borderWidth: 0,
                        gaugeData: {
                            value: 32,
                            valueColor: "#ff7143"
                        },
                        gaugeLimits: [0, 50, 100, 150]
                    }]
                },
                options: {
                        events: [],
                        showMarkers: true,
                        markerFormatFn :  n => n + 'm³/s',
                        formatDataValue :  n => n + 'm³/s',**
                }
            });
```

before the center text is 32.

**after the center text is 32m³/s**

only add **formatDataValue** attribute (is a function) in options.